### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ engines:
 
 ## Sonar Documentation
 
-http://www.sonarlint.org/commandline
+http://www.sonarlint.org/
 
 http://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner
 


### PR DESCRIPTION
The link to http://www.sonarlint.org/commandline is broken.

Also, according to the documentation on https://docs.codeclimate.com/docs/sonar-php this plugin doesn't only use sonarlint but also sonarphp and it would check for Security issues.

It doesn't seem clear in this documentation how sonarPHP is invloved?

The plugin doesn't detect any of the issues listed here: https://rules.sonarsource.com/php